### PR TITLE
github action for markdown linting + link checking

### DIFF
--- a/.github/workflows/markdownlint.yml
+++ b/.github/workflows/markdownlint.yml
@@ -1,0 +1,20 @@
+name: markdownlint
+on: [pull_request]
+
+jobs:
+  markdownlint:
+    name: markdownlint
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v2
+
+      - name: md-lint
+        uses: reviewdog/action-markdownlint@v0.1
+        with:
+            github_token: ${{ secrets.GITHUB_TOKEN }}
+            reporter: github-pr-review
+      - name: md-link-check
+        uses: gaurav-nelson/github-action-markdown-link-check@v1
+        with:
+            use-verbose-mode: 'yes'


### PR DESCRIPTION
I've tested this a bit and seems to work okay. Think we can enable this just for PRs. 
There's also ability to customise different options.

* use <https://github.com/reviewdog/action-markdownlint> for linting markdown. This uses reviewdog
  (<https://github.com/reviewdog/reviewdog>) to post review comments for problematic markdown chunks.
  The linter itself is <https://github.com/DavidAnson/markdownlint>, which is also the more popular VS Code extension.
* use <https://github.com/gaurav-nelson/github-action-markdown-link-check> for checking links. We can specify links to ignore using special comments e.g. links to our private repos.

Example outputs:

<img width="827" alt="Screen Shot 2021-01-27 at 12 01 41 pm" src="https://user-images.githubusercontent.com/29562861/105927147-82758480-6097-11eb-8a45-1440cb547421.png">
<img width="624" alt="Screen Shot 2021-01-27 at 11 17 06 am" src="https://user-images.githubusercontent.com/29562861/105927166-8bfeec80-6097-11eb-9b2c-51bd114d7f21.png">
