### PR TITLE
Add markdownlint config file

### DIFF
--- a/.markdownlintrc
+++ b/.markdownlintrc
@@ -1,0 +1,7 @@
+{
+  "default": true,
+  "line-length": true,
+  "no-inline-html": {
+    "allowed_elements": ["details", "img"]
+  }
+}

--- a/README.md
+++ b/README.md
@@ -1,14 +1,14 @@
 # Overview
 
-This repository contains documentation you might find useful when working at
-the Centre for Population Genomics.
+This repository contains documentation you might find useful when working at the
+Centre for Population Genomics.
 
 If anything seems unclear to you, please open an issue. If you have an idea on
 how to improve the text, e.g. updating instructions, please submit a pull
 request.
 
-If you need help more urgently, don't hesitate to ask directly on Slack (e.g.
-in the `#team-software` or `#team-analysis` channels).
+If you need help more urgently, don't hesitate to ask directly on Slack (e.g. in
+the `#team-software` or `#team-analysis` channels).
 
 - [Getting started](getting_started.md)
 - [Reproducible analyses](reproducible_analyses.md)

--- a/code_editors.md
+++ b/code_editors.md
@@ -1,6 +1,12 @@
-# Visual Studio Code
+# Code Editors
 
-## Hail
+- [Code Editors](#code-editors)
+  - [Visual Studio Code](#visual-studio-code)
+    - [Hail](#hail)
+
+## Visual Studio Code
+
+### Hail
 
 After installing the Python extension, Visual Studio Code by default uses
 Pylance for code navigation. As Hail requires a non-trivial `PYTHONPATH` to
@@ -31,9 +37,9 @@ Studio Code and run the following to install the required dependencies:
     ```
 
 Switch Visual Studio Code to this conda environment using the "Python: Select
-Interpreter" command. You might also want to disable the [inheritEnv
-setting](https://github.com/microsoft/vscode-python/issues/7607) when using
-conda.
+Interpreter" command. You might also want to disable the
+[inheritEnv setting](https://github.com/microsoft/vscode-python/issues/7607)
+when using conda.
 
 If symbols still don't get resolved properly, you might have to reload Visual
 Studio Code.

--- a/getting_started.md
+++ b/getting_started.md
@@ -3,6 +3,14 @@
 This document describes the commonly used technologies at the Centre, together
 with some hints on how to use various tools.
 
+- [Welcome to the CPG](#welcome-to-the-cpg)
+  - [GitHub](#github)
+  - [Code reviews](#code-reviews)
+  - [Google Cloud Platform](#google-cloud-platform)
+  - [Hail](#hail)
+  - [Hail Batch](#hail-batch)
+  - [Terra / Cromwell](#terra--cromwell)
+
 ## GitHub
 
 All source code is managed in GitHub repositories in the

--- a/getting_started.md
+++ b/getting_started.md
@@ -5,14 +5,15 @@ with some hints on how to use various tools.
 
 ## GitHub
 
-All source code is managed in GitHub repositories in the [populationgenomics
-organization](https://github.com/populationgenomics). Please let your manager
-know if you're not a member of either the [software or analysis
-team](https://github.com/orgs/populationgenomics/teams) yet.
+All source code is managed in GitHub repositories in the
+[populationgenomics organization](https://github.com/populationgenomics). Please
+let your manager know if you're not a member of either the
+[software or analysis team](https://github.com/orgs/populationgenomics/teams)
+yet.
 
-We manage projects using GitHub's [project
-boards](https://github.com/orgs/populationgenomics/projects) that link to
-issues across the different repositories.
+We manage projects using GitHub's
+[project boards](https://github.com/orgs/populationgenomics/projects) that link
+to issues across the different repositories.
 
 If you need a new repository, please reach out to the software team. As a
 principle, we try to use public repositories whenever possible.
@@ -38,29 +39,29 @@ together on a shared code base.
 
 For code reviews to work well, it's helpful to follow a few general guidelines:
 
-- Don't interpret review comments as criticism of your code. Instead,
-  consider them an opportunity to improve the code and learn new techniques.
+- Don't interpret review comments as criticism of your code. Instead, consider
+  them an opportunity to improve the code and learn new techniques.
 - It's really important that reviews are done in a timely fashion. Try to
   respond to review requests within 24 hours. If you don't hear back from a
   reviewer, feel free to "ping" them on Slack.
 - In order for people to respond quickly to reviews, individual pull requests
   (PRs) need to be small. Don't send thousands of lines of code for review:
   that's not fun for the reviewer, and it's unlikely you'll get good review
-  feedback. Instead, send small PRs frequently, so the reviewer can really
-  focus on the change.
+  feedback. Instead, send small PRs frequently, so the reviewer can really focus
+  on the change.
 - If a reviewer doesn't understand the code or has a question about it, it's
-  likely that a future maintainer will have a similar problem. Therefore,
-  don't just respond to the question using the review comment UI, but think
-  about how to make the code more readable. Should there be a clarifying code
-  comment, could you change the structure of the code, or rename a function
-  or variable to avoid the confusion?
+  likely that a future maintainer will have a similar problem. Therefore, don't
+  just respond to the question using the review comment UI, but think about how
+  to make the code more readable. Should there be a clarifying code comment,
+  could you change the structure of the code, or rename a function or variable
+  to avoid the confusion?
 - Code reviews are very different from pair programming. It's an asynchronous
   activity. Make sure to prepare your PR in a way that preempts any questions
   you can anticipate, to speed up the overall process.
 - It's normal that there might be a few rounds of back-and-forth. However, a
-  review should always be a technically focussed conversation, with the
-  common goal to improve the quality of the code. As a reviewer, make
-  concrete suggestions on how to improve the code.
+  review should always be a technically focussed conversation, with the common
+  goal to improve the quality of the code. As a reviewer, make concrete
+  suggestions on how to improve the code.
 
 It's okay to spend a lot of time on reviews! This is a big part of your
 responsibilities, and we really care about high code quality.
@@ -70,17 +71,17 @@ between the old code and the new proposed changes. You can make comments on
 specific lines of the code. Feel free to ask questions here, especially if you
 don’t understand something! It’s a good idea to think critically about the
 changes. There should also be tests either added or existing to make sure the
-code changes do not break any existing functionality and actually implement
-what was intended.
+code changes do not break any existing functionality and actually implement what
+was intended.
 
 If there are items for the author to address, then submit your review with
 "Request Changes". Otherwise, once you are happy with the changes and all
 comments have been addressed, you can "Approve" the PR.
 
-After approving, you can also merge the PR. Unless you added any feedback
-(even minor one: thoughts, minor suggestions, pointers to something related) -
-in this case, it's preferrable to leave merging to the author in case the
-author wants to act on your feedback.
+After approving, you can also merge the PR. Unless you added any feedback (even
+minor one: thoughts, minor suggestions, pointers to something related) - in this
+case, it's preferrable to leave merging to the author in case the author wants
+to act on your feedback.
 
 When merging, preferably use "squash merging" to keep the history clean; the
 exception to this are upstream merges where you want to keep all commits.
@@ -96,10 +97,10 @@ any development branches.
 
 ## Google Cloud Platform
 
-To make sure we don't run into scalability limits with increasing dataset
-sizes, we run all analyses at the Centre in a cloud computing environment. For
-now, we're using Google Cloud Platform (GCP), since projects like Terra and
-Hail so far work best on GCP.
+To make sure we don't run into scalability limits with increasing dataset sizes,
+we run all analyses at the Centre in a cloud computing environment. For now,
+we're using Google Cloud Platform (GCP), since projects like Terra and Hail so
+far work best on GCP.
 
 To install the Google Cloud SDK:
 
@@ -112,14 +113,14 @@ To install the Google Cloud SDK:
    conda activate gcp
    ```
 
-If you're new to GCP, read the excellent [How to
-Cloud](https://github.com/danking/hail-cloud-docs/blob/master/how-to-cloud.md)
+If you're new to GCP, read the excellent
+[How to Cloud](https://github.com/danking/hail-cloud-docs/blob/master/how-to-cloud.md)
 guide first.
 
 For better isolation and cost accounting, we create separate GCP projects for
 each effort within the Centre. For example, the TOB-WGS effort would have a
 dedicated GCP project called `tob-wgs`. It's important to keep in mind that the
-GCP project *name* can be distinct from the project *ID*. In general, when you
+GCP project _name_ can be distinct from the project _ID_. In general, when you
 specify projects, you'll have to use the project ID (e.g.
 `gcloud config set project <project-id>`).
 
@@ -128,19 +129,19 @@ are managed using Google Groups that are linked to IAM permission roles. Take a
 look at our [storage policies](storage_policies) for a much more detailed
 description.
 
-It's very important to avoid [network egress
-traffic](https://cloud.google.com/vpc/network-pricing#internet_egress) whenever
-possible: for example, copying 1 TB of data from the US to Australia costs 190
-USD. To avoid these costs, always make sure that the GCP buckets that store
-your data are colocated with the machines that access the data (typically in
-the `australia-southeast1` region).
+It's very important to avoid
+[network egress traffic](https://cloud.google.com/vpc/network-pricing#internet_egress)
+whenever possible: for example, copying 1 TB of data from the US to Australia
+costs 190 USD. To avoid these costs, always make sure that the GCP buckets that
+store your data are colocated with the machines that access the data (typically
+in the `australia-southeast1` region).
 
-The exception to this rule are public buckets that don't have the [Requester
-Pays](https://cloud.google.com/storage/docs/requester-pays) feature enabled,
-such as `gs://genomics-public-data`, `gs://gcp-public-data--broad-references`,
-or `gs://gcp-public-data--gnomad`. Even though data is copied from the US to
-Australia when accessing these buckets, we don't get charged for the egress
-traffic.
+The exception to this rule are public buckets that don't have the
+[Requester Pays](https://cloud.google.com/storage/docs/requester-pays) feature
+enabled, such as `gs://genomics-public-data`,
+`gs://gcp-public-data--broad-references`, or `gs://gcp-public-data--gnomad`.
+Even though data is copied from the US to Australia when accessing these
+buckets, we don't get charged for the egress traffic.
 
 Please avoid storing any non-public data on your laptop, as that increases the
 risk of data breaches. Keep in mind that any non-public genomic data is highly
@@ -155,8 +156,8 @@ scalability and our good relationship with the Hail development team, it's the
 Centre's main analysis platform.
 
 To install Hail, use the
-[package](https://github.com/populationgenomics/hail/tree/main/conda) in
-CPG's conda channel:
+[package](https://github.com/populationgenomics/hail/tree/main/conda) in CPG's
+conda channel:
 
 1. Install
    [Miniconda](https://docs.conda.io/projects/conda/en/latest/user-guide/install/index.html).
@@ -167,16 +168,16 @@ CPG's conda channel:
    conda activate hail
    ```
 
-The Hail [documentation](https://hail.is/docs/0.2/index.html) is a good
-starting point. In particular, the
+The Hail [documentation](https://hail.is/docs/0.2/index.html) is a good starting
+point. In particular, the
 [tutorials](https://hail.is/docs/0.2/tutorials-landing.html) are worth looking
 into.
 
 Don't feel discouraged if the "lazy evaluation" model of Hail feels unintuitive
 at first. It takes some time getting used to, but it's extremely powerful.
 
-To understand how Hail works on GCP, read the [How to Cloud with
-Hail](https://github.com/danking/hail-cloud-docs/blob/master/how-to-cloud-with-hail.md)
+To understand how Hail works on GCP, read the
+[How to Cloud with Hail](https://github.com/danking/hail-cloud-docs/blob/master/how-to-cloud-with-hail.md)
 guide.
 
 At the moment, using Hail requires launching a Dataproc (Spark) cluster. Please
@@ -188,16 +189,16 @@ completed:
 hailctl dataproc start --max-age 2h --region australia-southeast1 my-cluster
 ```
 
-There's also a [workshop
-recording](https://drive.google.com/file/d/1c5us8YSApSGl81CrojeR426wTS2QA53d/view?usp=sharing)
-that contains a lot of useful tips, although not everything is applicable to
-the Centre.
+There's also a
+[workshop recording](https://drive.google.com/file/d/1c5us8YSApSGl81CrojeR426wTS2QA53d/view?usp=sharing)
+that contains a lot of useful tips, although not everything is applicable to the
+Centre.
 
 If you have any Hail related questions, feel free to ask on Slack in the
-`#team-analysis` channel. The Hail team is also very responsive in the [Zulip
-chat](https://hail.zulipchat.com), but you'll have to take the time zone
-difference into account. Finally, there's also an official [discussion
-forum](https://discuss.hail.is/).
+`#team-analysis` channel. The Hail team is also very responsive in the
+[Zulip chat](https://hail.zulipchat.com), but you'll have to take the time zone
+difference into account. Finally, there's also an official
+[discussion forum](https://discuss.hail.is/).
 
 If you're interested in the Hail internals, this developer focussed
 [overview](https://github.com/hail-is/hail/blob/main/dev-docs/hail-overview.md)
@@ -208,22 +209,24 @@ is very helpful.
 [Hail Batch](https://hail.is/docs/batch/service.html) is a generic job
 scheduling system: you describe a workflow using a Python API as a series of
 jobs consisting of Docker container commands, input and output files, and job
-interdependencies. Hail Batch then runs that workflow in GCP using a
-dynamically scaled pool of workers.
+interdependencies. Hail Batch then runs that workflow in GCP using a dynamically
+scaled pool of workers.
 
-In the near future, Hail Batch will integrate nicely with the Hail *Query*
+In the near future, Hail Batch will integrate nicely with the Hail _Query_
 component, which means that you won't need to run a Dataproc cluster anymore.
-Instead, you'll be able to run scalable Hail analyses directly from Batch,
-using a shared pool of worker VMs that also process your other jobs.
+Instead, you'll be able to run scalable Hail analyses directly from Batch, using
+a shared pool of worker VMs that also process your other jobs.
 
-To avoid network egress costs, we run our own Hail Batch deployment in
-Australia using the `hail.populationgenomics.org.au` domain. Consequently, the
-worker VMs are located in the `australia-southeast1` region, which is typically
-colocated with the buckets that store our datasets.
+To avoid network egress costs, we run our own Hail Batch deployment in Australia
+using the `hail.populationgenomics.org.au` domain. Consequently, the worker VMs
+are located in the `australia-southeast1` region, which is typically colocated
+with the buckets that store our datasets.
 
-The `hailctl` tool you've installed previously can also be used to interact
-with Hail Batch. To point it at the correct domain, you have to set up a
-deployment configuration:
+The `hailctl` tool you've installed previously can also be used to interact with
+Hail Batch. To point it at the correct domain, you have to set up a deployment
+configuration:
+
+<!-- markdownlint-disable -->
 
 ```bash
 mkdir ~/.hail
@@ -231,12 +234,14 @@ mkdir ~/.hail
 echo '{"location": "external", "default_namespace": "default", "domain": "hail.populationgenomics.org.au"}' > ~/.hail/deploy-config.json
 ```
 
-To create a Hail Batch account, visit the [sign-up
-page](https://auth.hail.populationgenomics.org.au/signup) using your
+<!-- markdownlint-restore -->
+
+To create a Hail Batch account, visit the
+[sign-up page](https://auth.hail.populationgenomics.org.au/signup) using your
 @populationgenomics.org.au Google Workspace account. Ignore the redirect to the
-notebook page, which currently isn't running. Instead, navigate to the [user
-page](https://auth.hail.populationgenomics.org.au/user) to see your account
-details.
+notebook page, which currently isn't running. Instead, navigate to the
+[user page](https://auth.hail.populationgenomics.org.au/user) to see your
+account details.
 
 You should now be able to authenticate from the commandline:
 
@@ -245,8 +250,8 @@ hailctl auth login
 ```
 
 To get familiar with the Hail Batch API, check out the
-[tutorial](https://hail.is/docs/batch/tutorial.html). There's also a [workshop
-recording](https://drive.google.com/file/d/1_Uo_OlKw6dJsBsa6bH5NwMinfLahDX6U/view?usp=sharing)
+[tutorial](https://hail.is/docs/batch/tutorial.html). There's also a
+[workshop recording](https://drive.google.com/file/d/1_Uo_OlKw6dJsBsa6bH5NwMinfLahDX6U/view?usp=sharing)
 that explains how to run workflows in Hail Batch.
 
 Note that billing projects in Hail are distinct from GCP projects. Initially,
@@ -254,10 +259,10 @@ you're assigned a small trial project. Let the software team know in case your
 user needs to have access to an existing billing project or if you need to
 create a new billing project.
 
-At the moment, you can submit jobs to Hail Batch by running the "driver"
-program (which defines the batch) locally. However, since that's problematic in
-terms of reproducibility, we're currently looking into ways to run the driver
-itself on Hail Batch, too.
+At the moment, you can submit jobs to Hail Batch by running the "driver" program
+(which defines the batch) locally. However, since that's problematic in terms of
+reproducibility, we're currently looking into ways to run the driver itself on
+Hail Batch, too.
 
 ## Terra / Cromwell
 
@@ -266,9 +271,9 @@ using Hail Query functionality, a lot of existing genomic pipelines (like
 Broad's GATK Best Practices Workflows) run on Cromwell.
 
 While [Terra](https://terra.bio/) is a great way to run such workflows, there
-are still a few features missing that would allow us to run production
-workflows in Australia.
+are still a few features missing that would allow us to run production workflows
+in Australia.
 
-For now, the best way to run workflows written in CWL or WDL is therefore to
-set up your own Cromwell server, which is fairly straightforward using our
+For now, the best way to run workflows written in CWL or WDL is therefore to set
+up your own Cromwell server, which is fairly straightforward using our
 [config templates](https://github.com/populationgenomics/cromwell-configs).

--- a/python_code_style.md
+++ b/python_code_style.md
@@ -1,5 +1,11 @@
 # Python Code Style
 
+- [Python Code Style](#python-code-style)
+  - [Setting up a new project](#setting-up-a-new-project)
+  - [Running Pylint](#running-pylint)
+  - [Visual Studio Code](#visual-studio-code)
+  - [PyCharm](#pycharm)
+
 We use [pylint](https://www.pylint.org/) to perform automatic code checks on our
 repositories. It helps us in implementing a consistent coding style throughout
 our code base, and also does some static code analysis to catch potential
@@ -7,8 +13,8 @@ programming errors.
 
 ## Setting up a new project
 
-When creating a new repository that contains Python code, please add this
-pylint configuration file into the repository root folder:
+When creating a new repository that contains Python code, please add this pylint
+configuration file into the repository root folder:
 
 ```sh
 wget https://raw.githubusercontent.com/populationgenomics/team-docs/main/\
@@ -24,8 +30,8 @@ disable=f-string-without-interpolation,inherit-non-class,too-few-public-methods,
 ```
 
 In addition to `.pylintrc`, create a GitHub Actions CI workflow under
-`.github/workflows/main.yaml` with the following contents (or add the `lint`
-job to an exsting workflow):
+`.github/workflows/main.yaml` with the following contents (or add the `lint` job
+to an exsting workflow):
 
 ```sh
 mkdir -p .github/workflows
@@ -46,9 +52,9 @@ To install Pylint into your environment, run:
 pip install pylint pylint-quotes
 ```
 
-`pylint-quotes` is a plugin to Pylint that adds checks of the consistency
-of quotes (we stick to single quotes, with the only reason to prefer them
-over double quotes being the visual noise).
+`pylint-quotes` is a plugin to Pylint that adds checks of the consistency of
+quotes (we stick to single quotes, with the only reason to prefer them over
+double quotes being the visual noise).
 
 To run Pylint manually, you can use:
 
@@ -71,10 +77,9 @@ the user whether to install pylint, if it's not installed already.
 
    <img src="assets/pycharm_pylint_tool_window.png" width="700"/>
 
-3. You can also enable real-time inspections by going to:
-   Go to Preferences > Editor > Inspections > enable "Pylint real-time scan".
-   However, it's not recommended as it's has a negative impact on system
-   performance.
+3. You can also enable real-time inspections by going to: Go to Preferences >
+   Editor > Inspections > enable "Pylint real-time scan". However, it's not
+   recommended as it's has a negative impact on system performance.
 
 4. Pylint has a pre-commit hook integrated into a PyCharm commit modal window (
    Cmd+K). Make sure the "Scan with Pylint" checkbox is enabled:

--- a/reproducible_analyses.md
+++ b/reproducible_analyses.md
@@ -2,25 +2,25 @@
 
 We'd like to be able to reproduce analysis results easily. While that's not
 always fully achievable, the strategies below help significantly. Note that
-this is only about analyses run on *production* data, not the development and
+this is only about analyses run on _production_ data, not the development and
 testing of new code.
 
-1. *Only run code that has been committed to a repository.*
+1. _Only run code that has been committed to a repository._
 
    If locally changed code is used to produce analysis results, those
    results can't be reproduced if the local changes get lost. To avoid this
    problem, the [analysis runner](https://github.com/populationgenomics/analysis-runner)
    fetches pipelines from GitHub repositories only.
 
-2. *Link the output data with the exact program invocation of how the data has
-   been generated.*
+2. _Link the output data with the exact program invocation of how the data has
+   been generated._
 
    Even if the code is committed to a repository, it's usually not obvious how
    a derived dataset was generated. The [analysis runner](https://github.com/populationgenomics/analysis-runner)
    therefore stores a file with the invocation details of the pipeline
    together with the output data.
 
-3. *Pin all dependencies of your code to a specific version.*
+3. _Pin all dependencies of your code to a specific version._
 
    Docker images, pip, conda, and many other systems let you specify version
    dependencies. Avoid using "latest", minimum version requirements or
@@ -29,7 +29,7 @@ testing of new code.
    We currently rely on code reviews to spot these issues. Ideally, we'd have
    a linter that checks the common cases.
 
-4. *Treat output data as immutable.*
+4. _Treat output data as immutable._
 
    If you overwrite (or delete) outputs, any data that has previously been
    derived from those outputs gets implicitly invalidated. By default we

--- a/reproducible_analyses.md
+++ b/reproducible_analyses.md
@@ -1,36 +1,38 @@
 # Reproducible analyses
 
 We'd like to be able to reproduce analysis results easily. While that's not
-always fully achievable, the strategies below help significantly. Note that
-this is only about analyses run on _production_ data, not the development and
-testing of new code.
+always fully achievable, the strategies below help significantly. Note that this
+is only about analyses run on _production_ data, not the development and testing
+of new code.
 
 1. _Only run code that has been committed to a repository._
 
-   If locally changed code is used to produce analysis results, those
-   results can't be reproduced if the local changes get lost. To avoid this
-   problem, the [analysis runner](https://github.com/populationgenomics/analysis-runner)
+   If locally changed code is used to produce analysis results, those results
+   can't be reproduced if the local changes get lost. To avoid this problem, the
+   [analysis runner](https://github.com/populationgenomics/analysis-runner)
    fetches pipelines from GitHub repositories only.
 
 2. _Link the output data with the exact program invocation of how the data has
    been generated._
 
-   Even if the code is committed to a repository, it's usually not obvious how
-   a derived dataset was generated. The [analysis runner](https://github.com/populationgenomics/analysis-runner)
-   therefore stores a file with the invocation details of the pipeline
-   together with the output data.
+   Even if the code is committed to a repository, it's usually not obvious how a
+   derived dataset was generated. The
+   [analysis runner](https://github.com/populationgenomics/analysis-runner)
+   therefore stores a file with the invocation details of the pipeline together
+   with the output data.
 
 3. _Pin all dependencies of your code to a specific version._
 
    Docker images, pip, conda, and many other systems let you specify version
-   dependencies. Avoid using "latest", minimum version requirements or
-   version ranges. Instead, always specify an exact version.
+   dependencies. Avoid using "latest", minimum version requirements or version
+   ranges. Instead, always specify an exact version.
 
-   We currently rely on code reviews to spot these issues. Ideally, we'd have
-   a linter that checks the common cases.
+   We currently rely on code reviews to spot these issues. Ideally, we'd have a
+   linter that checks the common cases.
 
 4. _Treat output data as immutable._
 
    If you overwrite (or delete) outputs, any data that has previously been
    derived from those outputs gets implicitly invalidated. By default we
-   therefore only allow creating new data in our [storage policies](storage_policies).
+   therefore only allow creating new data in our
+   [storage policies](storage_policies).

--- a/storage_policies/README.md
+++ b/storage_policies/README.md
@@ -1,14 +1,29 @@
 # Storage policies
 
-This document describes where our production datasets are stored, how [object
-lifecycles](https://cloud.google.com/storage/docs/lifecycle)
-are configured, and how access permissions are managed.
+- [Storage policies](#storage-policies)
+  - [Typical data flow](#typical-data-flow)
+  - [Buckets](#buckets)
+  - [reference: `gs://cpg-reference`](#reference-gscpg-reference)
+  - [upload: `gs://cpg-$STACK-upload`](#upload-gscpg-stack-upload)
+  - [archive: `gs://cpg-$STACK-archive`](#archive-gscpg-stack-archive)
+  - [main: `gs://cpg-$STACK-main`](#main-gscpg-stack-main)
+  - [test: `gs://cpg-$STACK-test`](#test-gscpg-stack-test)
+  - [analysis: `gs://cpg-$STACK-analysis`](#analysis-gscpg-stack-analysis)
+  - [temporary: `gs://cpg-$STACK-temporary`](#temporary-gscpg-stack-temporary)
+  - [release: `gs://cpg-$STACK-release-requester-pays`](#release-gscpg-stack-release-requester-pays)
+  - [Deletion](#deletion)
+  - [Access permissions](#access-permissions)
+  - [Analysis runner](#analysis-runner)
+  - [Automation](#automation)
+
+This document describes where our production datasets are stored, how
+[object lifecycles](https://cloud.google.com/storage/docs/lifecycle) are
+configured, and how access permissions are managed.
 
 We are trying to strike a balance between:
 
 - Quick development iterations and unlimited ad-hoc data exploration.
-- Robust, reproducible pipelines, using only strictly necessary cloud
-  resources.
+- Robust, reproducible pipelines, using only strictly necessary cloud resources.
 
 This motivates two somewhat unusual principles in the design:
 
@@ -16,11 +31,10 @@ This motivates two somewhat unusual principles in the design:
   representative) subset of the data (blue highlight in the graph below). The
   full dataset is only accessible through code that has been reviewed and
   committed (green highlight in the graph below).
-- All outputs are versioned and immutable, except for purely temporary
-  results (yellow highlight in the graph below). Since "production runs" of
-  pipelines only happen after sufficient testing on subsets of the data,
-  immutable results generally shouldn't cause a lot of churn or resource
-  usage.
+- All outputs are versioned and immutable, except for purely temporary results
+  (yellow highlight in the graph below). Since "production runs" of pipelines
+  only happen after sufficient testing on subsets of the data, immutable results
+  generally shouldn't cause a lot of churn or resource usage.
 
 ## Typical data flow
 
@@ -38,8 +52,8 @@ therefore essential that all computation happens in that region too, to avoid
 network egress costs.
 
 In general, all datasets within buckets should be versioned, using a simple
-major-minor naming scheme like `gs://cpg-$STACK-main/qc/v1.2/`. We don't have
-a strict semantic definition to distinguish between major and minor version
+major-minor naming scheme like `gs://cpg-$STACK-main/qc/v1.2/`. We don't have a
+strict semantic definition to distinguish between major and minor version
 increments. The addition of significant numbers of samples or the use of a
 substantially different analysis method usually justifies a major version
 increase.
@@ -47,9 +61,9 @@ increase.
 ## reference: `gs://cpg-reference`
 
 This bucket contains reference data that's independent of any particular stack,
-e.g. the GRCh38 human reference genome sequences used for alignment, the
-GENCODE GTF used for functional annotations, the version of dbSNP used to add
-rsIDs, etc. These resource "bundles" are versioned together.
+e.g. the GRCh38 human reference genome sequences used for alignment, the GENCODE
+GTF used for functional annotations, the version of dbSNP used to add rsIDs,
+etc. These resource "bundles" are versioned together.
 
 Most pipelines will depend on this bucket to some degree.
 
@@ -62,36 +76,36 @@ Everybody in the organization has viewer permissions.
 This bucket contains files uploaded from sequencing providers, as a staging
 area.
 
-The main use case for this category are raw sequencing reads (e.g. CRAM
-files) and derived data from initial production pipelines: QC metrics
-including coverage results, and additional outputs from variant callers (e.g.
-structural variants, repeat expansions, etc.), and GVCFs.
+The main use case for this category are raw sequencing reads (e.g. CRAM files)
+and derived data from initial production pipelines: QC metrics including
+coverage results, and additional outputs from variant callers (e.g. structural
+variants, repeat expansions, etc.), and GVCFs.
 
 An upload processor pipeline moves these files into the _archive_ and _main_
 buckets in batches, creating new releases.
 
-Files stay in Standard Storage indefinitely, but are cleared up regularly by
-the upload processor.
+Files stay in Standard Storage indefinitely, but are cleared up regularly by the
+upload processor.
 
 Access is restricted to service accounts that run workflows. Sequencing
 providers have creator permissions, using a service account.
 
 ## archive: `gs://cpg-$STACK-archive`
 
-This bucket contains files for _archival purposes_: long term storage is
-cheap, but _retrieval is very expensive_.
+This bucket contains files for _archival purposes_: long term storage is cheap,
+but _retrieval is very expensive_.
 
-The main use case for this category are raw sequencing reads (e.g. CRAM
-files). After conversion to Hail MatrixTables, GVCF files can potentially be
-stored here as well.
+The main use case for this category are raw sequencing reads (e.g. CRAM files).
+After conversion to Hail MatrixTables, GVCF files can potentially be stored here
+as well.
 
 Files stay in Standard Storage for 30 days, before their storage class gets
 changed to Archive Storage. This allows workflows to do post-processing of the
 data shortly after initial creation (e.g. copying windowed regions of raw reads
 around interesting variants) before retrieval becomes expensive.
 
-Access is restricted to service accounts that run workflows, to avoid
-accidental retrieval costs incurred by human readers.
+Access is restricted to service accounts that run workflows, to avoid accidental
+retrieval costs incurred by human readers.
 
 ## main: `gs://cpg-$STACK-main`
 
@@ -104,14 +118,14 @@ metadata, SV caller outputs, transcript abundance files, etc.
 Files stay in Standard Storage indefinitely.
 
 Human users only get listing permissions, but viewer permissions are granted
-indirectly through the [analysis runner](#analysis-runner) described below.
-This avoids high costs through code that hasn't been reviewed. See the _test_
-bucket below if you're developing / prototyping a new pipeline.
+indirectly through the [analysis runner](#analysis-runner) described below. This
+avoids high costs through code that hasn't been reviewed. See the _test_ bucket
+below if you're developing / prototyping a new pipeline.
 
 ## test: `gs://cpg-$STACK-test`
 
-This bucket contains _input_ test data, which usually corresponds to a subset
-of the data stored in the _main_ bucket. Long term storage is expensive, but
+This bucket contains _input_ test data, which usually corresponds to a subset of
+the data stored in the _main_ bucket. Long term storage is expensive, but
 retrieval is cheap.
 
 The main use case is to iterate quickly on new pipelines during development.
@@ -129,8 +143,8 @@ This bucket contains files that are frequently accessed for analysis.
 
 Long term storage is expensive, but retrieval is cheap.
 
-The main use case for this category are analysis results derived from the
-_main_ bucket, which in turn can become inputs for further analyses.
+The main use case for this category are analysis results derived from the _main_
+bucket, which in turn can become inputs for further analyses.
 
 Files stay in Standard Storage indefinitely.
 
@@ -155,12 +169,12 @@ through a file name prefix).
 ## release: `gs://cpg-$STACK-release-requester-pays`
 
 This bucket contains data that's shared with other researchers or is publicly
-available. Long term storage is expensive, but network egress costs are
-covered by the users who download the data.
+available. Long term storage is expensive, but network egress costs are covered
+by the users who download the data.
 
-The main use case for this category are aggregate results that are made
-publicly available or snapshots of datasets that are shared with other
-researchers through restricted access.
+The main use case for this category are aggregate results that are made publicly
+available or snapshots of datasets that are shared with other researchers
+through restricted access.
 
 Files stay in Standard Storage indefinitely.
 
@@ -183,31 +197,31 @@ accidental deletion.
 
 Permissions are managed through IAM, using access groups.
 
-- `$STACK-restricted-access@populationgenomics.org.au`: human users are added
-  to this group to gain permissions as described above. Membership should
-  usually expire after a year, after which continued access will require a
-  membership renewal.
+- `$STACK-restricted-access@populationgenomics.org.au`: human users are added to
+  this group to gain permissions as described above. Membership should usually
+  expire after a year, after which continued access will require a membership
+  renewal.
 - `$STACK-extended-access@populationgenomics.org.au`: grants members admin
   permissions to all buckets. This should generally only be necessary for
   service accounts and very rarely for human users (in which case membership
   should expire after a short amount of time).
 - `$STACK-release-access@populationgenomics.org.au`: grants members viewer
   permissions to the _release_ bucket. Only required if the releases are not
-  public. This usually includes users outside the CPG, in which case they
-  must use Google accounts. Membership should usually expire after a year,
-  after which continued access will require a membership renewal.
+  public. This usually includes users outside the CPG, in which case they must
+  use Google accounts. Membership should usually expire after a year, after
+  which continued access will require a membership renewal.
 
 ## Analysis runner
 
-To encourage reproducible workflows and code getting reviewed before it's run
-on "production data", viewer permissions to the _main_ bucket and creator
+To encourage reproducible workflows and code getting reviewed before it's run on
+"production data", viewer permissions to the _main_ bucket and creator
 permissions to the _analysis_ bucket are available only through the analysis
 runner. The typical workflow looks like this:
 
 1. Protoype and iterate on your pipeline using the _test_ bucket for input and
    the _temporary_ bucket for outputs.
-1. Once you're ready to run your pipeline on the _main_ bucket for input,
-   create a pull request to get your code reviewed.
+1. Once you're ready to run your pipeline on the _main_ bucket for input, create
+   a pull request to get your code reviewed.
 1. After your pull request has been merged, note the corresponding git commit
    hash. Invoke the analysis runner with that commit hash, which will run the
    pipeline on your behalf and store additional metadata.
@@ -216,8 +230,8 @@ For more detailed instructions and examples, look at the
 [analysis runner repository](https://github.com/populationgenomics/analysis-runner).
 
 If this causes too much friction in your daily work, please don't work around
-the restrictions. Instead, reach out to the software team, so we can work
-on process improvements together.
+the restrictions. Instead, reach out to the software team, so we can work on
+process improvements together.
 
 ## Automation
 
@@ -226,11 +240,13 @@ Buckets and permission groups can be brought up using Pulumi.
 1. Create a new GCP project for the stack, corresponding to `$PROJECT` below.
 1. Configure the Pulumi stack options:
 
-   - See this [issue](https://github.com/hashicorp/terraform-provider-google/issues/7477)
+   - See this
+     [issue](https://github.com/hashicorp/terraform-provider-google/issues/7477)
      regarding the use of the `user_project_override` and `billing_project`
      options below.
    - You can find your organization's `$CUSTOMER_ID` (used for creating Cloud
-     Identity IAM groups) using [Resource Manager](https://cloud.google.com/resource-manager/reference/rest/v1/organizations/search).
+     Identity IAM groups) using
+     [Resource Manager](https://cloud.google.com/resource-manager/reference/rest/v1/organizations/search).
 
    ```shell
    cd stack

--- a/storage_policies/README.md
+++ b/storage_policies/README.md
@@ -29,7 +29,7 @@ This motivates two somewhat unusual principles in the design:
 ## Buckets
 
 In this context, a stack corresponds to a particular project / effort, e.g.
-*TOB-WGS* or *RDNow*, with separate buckets and permission groups. Below,
+_TOB-WGS_ or _RDNow_, with separate buckets and permission groups. Below,
 `$STACK` is a placeholder for the name of that effort, e.g. `$STACK` =
 `tob-wgs`.
 
@@ -67,7 +67,7 @@ files) and derived data from initial production pipelines: QC metrics
 including coverage results, and additional outputs from variant callers (e.g.
 structural variants, repeat expansions, etc.), and GVCFs.
 
-An upload processor pipeline moves these files into the *archive* and *main*
+An upload processor pipeline moves these files into the _archive_ and _main_
 buckets in batches, creating new releases.
 
 Files stay in Standard Storage indefinitely, but are cleared up regularly by
@@ -78,8 +78,8 @@ providers have creator permissions, using a service account.
 
 ## archive: `gs://cpg-$STACK-archive`
 
-This bucket contains files for *archival purposes*: long term storage is
-cheap, but *retrieval is very expensive*.
+This bucket contains files for _archival purposes_: long term storage is
+cheap, but _retrieval is very expensive_.
 
 The main use case for this category are raw sequencing reads (e.g. CRAM
 files). After conversion to Hail MatrixTables, GVCF files can potentially be
@@ -95,7 +95,7 @@ accidental retrieval costs incurred by human readers.
 
 ## main: `gs://cpg-$STACK-main`
 
-This bucket contains *input* files that are frequently accessed for analysis.
+This bucket contains _input_ files that are frequently accessed for analysis.
 Long term storage is expensive, but retrieval is cheap.
 
 The main use case for this category are Hail tables (e.g. merged GVCF files),
@@ -105,13 +105,13 @@ Files stay in Standard Storage indefinitely.
 
 Human users only get listing permissions, but viewer permissions are granted
 indirectly through the [analysis runner](#analysis-runner) described below.
-This avoids high costs through code that hasn't been reviewed. See the *test*
+This avoids high costs through code that hasn't been reviewed. See the _test_
 bucket below if you're developing / prototyping a new pipeline.
 
 ## test: `gs://cpg-$STACK-test`
 
-This bucket contains *input* test data, which usually corresponds to a subset
-of the data stored in the *main* bucket. Long term storage is expensive, but
+This bucket contains _input_ test data, which usually corresponds to a subset
+of the data stored in the _main_ bucket. Long term storage is expensive, but
 retrieval is cheap.
 
 The main use case is to iterate quickly on new pipelines during development.
@@ -130,7 +130,7 @@ This bucket contains files that are frequently accessed for analysis.
 Long term storage is expensive, but retrieval is cheap.
 
 The main use case for this category are analysis results derived from the
-*main* bucket, which in turn can become inputs for further analyses.
+_main_ bucket, which in turn can become inputs for further analyses.
 
 Files stay in Standard Storage indefinitely.
 
@@ -139,7 +139,7 @@ indirectly through the [analysis runner](#analysis-runner) described below.
 
 ## temporary: `gs://cpg-$STACK-temporary`
 
-This bucket contains files that only need to be retained *temporarily* during
+This bucket contains files that only need to be retained _temporarily_ during
 analysis or workflow execution. Retrieval is cheap, but old files get
 automatically deleted.
 
@@ -170,7 +170,7 @@ modification / deletion of files.
 ## Deletion
 
 By default, human users can't delete objects in any bucket except for the
-*temporary* bucket. This avoids accidental deletion of results and makes sure
+_temporary_ bucket. This avoids accidental deletion of results and makes sure
 our pipelines stay reproducible. However, it will sometimes be necessary to
 delete obsolete results, mainly to reduce storage costs. Please coordinate
 directly with the software team in such cases.
@@ -192,7 +192,7 @@ Permissions are managed through IAM, using access groups.
   service accounts and very rarely for human users (in which case membership
   should expire after a short amount of time).
 - `$STACK-release-access@populationgenomics.org.au`: grants members viewer
-  permissions to the *release* bucket. Only required if the releases are not
+  permissions to the _release_ bucket. Only required if the releases are not
   public. This usually includes users outside the CPG, in which case they
   must use Google accounts. Membership should usually expire after a year,
   after which continued access will require a membership renewal.
@@ -200,13 +200,13 @@ Permissions are managed through IAM, using access groups.
 ## Analysis runner
 
 To encourage reproducible workflows and code getting reviewed before it's run
-on "production data", viewer permissions to the *main* bucket and creator
-permissions to the *analysis* bucket are available only through the analysis
+on "production data", viewer permissions to the _main_ bucket and creator
+permissions to the _analysis_ bucket are available only through the analysis
 runner. The typical workflow looks like this:
 
-1. Protoype and iterate on your pipeline using the *test* bucket for input and
-   the *temporary* bucket for outputs.
-1. Once you're ready to run your pipeline on the *main* bucket for input,
+1. Protoype and iterate on your pipeline using the _test_ bucket for input and
+   the _temporary_ bucket for outputs.
+1. Once you're ready to run your pipeline on the _main_ bucket for input,
    create a pull request to get your code reviewed.
 1. After your pull request has been merged, note the corresponding git commit
    hash. Invoke the analysis runner with that commit hash, which will run the
@@ -225,6 +225,7 @@ Buckets and permission groups can be brought up using Pulumi.
 
 1. Create a new GCP project for the stack, corresponding to `$PROJECT` below.
 1. Configure the Pulumi stack options:
+
    - See this [issue](https://github.com/hashicorp/terraform-provider-google/issues/7477)
      regarding the use of the `user_project_override` and `billing_project`
      options below.


### PR DESCRIPTION
* Setting up a config for markdownlint:
  - recognised by VS Code's markdownlint extension
  - lint lines > 80 columns
  - allow only `img` and `details` HTML tags in markdown
* Added a table of contents to most markdown docs.
* Used prettier and VS Code's autoformatter to wrap lines (mostly involved keeping links on a single line and replacing instances of `*italic* with _italic_`).