### PR TITLE
Linting adjustments

### DIFF
--- a/.flake8
+++ b/.flake8
@@ -4,7 +4,8 @@
 #    any formatting for consistent looks and for future safety)
 # 2. Inspections incompatible with Black (see https://github.com/psf/black/blob/master/docs/compatible_configs.md#why-those-options-above-1):
 #    E203: whitespace before ':'
-extend-ignore: F541,E203
+# 3. Q003 ("Change outer quotes to avoid escaping inner quotes")
+extend-ignore: F541,E203,Q003
 
 # Maximum number of characters on a single line. Default for black, see:
 # https://black.readthedocs.io/en/stable/the_black_code_style.html#line-length

--- a/linting/flake8
+++ b/linting/flake8
@@ -4,7 +4,8 @@
 #    any formatting for consistent looks and for future safety)
 # 2. Inspections incompatible with Black (see https://github.com/psf/black/blob/master/docs/compatible_configs.md#why-those-options-above-1):
 #    E203: whitespace before ':'
-extend-ignore: F541,E203
+# 3. Q003 ("Change outer quotes to avoid escaping inner quotes")
+extend-ignore: F541,E203,Q003
 
 # Maximum number of characters on a single line. Default for black, see:
 # https://black.readthedocs.io/en/stable/the_black_code_style.html#line-length

--- a/linting/markdownlint.json
+++ b/linting/markdownlint.json
@@ -3,5 +3,9 @@
   "line-length": false,
   "no-inline-html": {
     "allowed_elements": ["details", "img"]
-  }
+  },
+  "ol-prefix": false,
+  "list-indent": false,
+  "ul-indent": false,
+  "no-multiple-blanks": false
 }

--- a/linting/pylintrc
+++ b/linting/pylintrc
@@ -10,8 +10,14 @@
 #    C0330: Wrong hanging indentation before block (add 4 spaces)
 #    C0326: Bad whitespace
 # 5. fixme (left 'TODO' lines)
+# 6. logging-fstring-interpolation (forbids f-strings in logging functions)
+# 7. The following require installing the python modules imported in the source code.
+#    Add these if you don't want to include all dependencies into the dev environment:
+#    import-error ("Unable to import")
+#    no-member
+#    c-extension-no-member
 
-disable=f-string-without-interpolation,inherit-non-class,too-few-public-methods,C0330,C0326,fixme
+disable=f-string-without-interpolation,inherit-non-class,too-few-public-methods,C0330,C0326,fixme,logging-fstring-interpolation
 
 # Overriding variable name patterns to allow short 1- or 2-letter variables
 attr-rgx=[a-z_][a-z0-9_]{0,30}$


### PR DESCRIPTION
1. Python: disabling Q003 "Change outer quotes to avoid escaping inner quotes" (after discussion with Michael) and `logging-fstring-interpolation`.

2. Disabling a few inspections for markdown that I find not very useful. Peter, adding you as a reviewer - let me know if you mind :)