### PR TITLE
Linting: conda yaml, max statements, log fstrings

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -3,6 +3,7 @@ repos:
   rev: v2.3.0
   hooks:
   - id: check-yaml
+    exclude: '\.*conda/.*'
   - id: end-of-file-fixer
   - id: trailing-whitespace
     exclude: '\.txt$|\.tsv$'

--- a/.pylintrc
+++ b/.pylintrc
@@ -10,13 +10,15 @@
 #    C0330: Wrong hanging indentation before block (add 4 spaces)
 #    C0326: Bad whitespace
 # 5. fixme (left 'TODO' lines)
-# 6. The following require installing the python modules imported in the source code
+# 6. logging-fstring-interpolation (forbids f-strings in logging functions)
+# 7. missing-function-docstring (Missing function or method docstring)
+# 8. The following require installing the python modules imported in the source code.
+#    Add these if you don't want to include all dependencies into the dev environment:
 #    import-error ("Unable to import")
 #    no-member
 #    c-extension-no-member
-# 7. missing-function-docstring (Missing function or method docstring)
 
-disable=f-string-without-interpolation,inherit-non-class,too-few-public-methods,C0330,C0326,fixme,import-error,no-member,c-extension-no-member,missing-function-docstring
+disable=f-string-without-interpolation,inherit-non-class,too-few-public-methods,C0330,C0326,fixme,logging-fstring-interpolation,import-error,no-member,c-extension-no-member
 
 # Overriding variable name patterns to allow short 1- or 2-letter variables
 attr-rgx=[a-z_][a-z0-9_]{0,30}$
@@ -32,3 +34,5 @@ max-line-length=88
 max-locals=25
 # Maximum number of arguments for function / method
 max-args=10
+# Maximum number of statements in function / method body
+max-statements=100

--- a/linting/pre-commit-config.yaml
+++ b/linting/pre-commit-config.yaml
@@ -3,6 +3,7 @@ repos:
   rev: v2.3.0
   hooks:
   - id: check-yaml
+    exclude: '\.*conda/.*'
   - id: end-of-file-fixer
   - id: trailing-whitespace
     exclude: '\.txt$|\.tsv$'

--- a/linting/pylintrc
+++ b/linting/pylintrc
@@ -11,7 +11,8 @@
 #    C0326: Bad whitespace
 # 5. fixme (left 'TODO' lines)
 # 6. logging-fstring-interpolation (forbids f-strings in logging functions)
-# 7. The following require installing the python modules imported in the source code.
+# 7. missing-function-docstring (Missing function or method docstring)
+# 8. The following require installing the python modules imported in the source code.
 #    Add these if you don't want to include all dependencies into the dev environment:
 #    import-error ("Unable to import")
 #    no-member
@@ -33,3 +34,5 @@ max-line-length=88
 max-locals=25
 # Maximum number of arguments for function / method
 max-args=10
+# Maximum number of statements in function / method body
+max-statements=100


### PR DESCRIPTION
- skip conda meta.yaml for yaml linter;
- pylint: raise max statements in a function 50 -> 100
- pylint: disable `logging-fstring-interpolation` to allow f-strings in logger functions
UPD:
- reenable `missing-function-docstring`