### PR TITLE
Add comments into own markdownlint config as well

### DIFF
--- a/.markdownlint.json
+++ b/.markdownlint.json
@@ -1,12 +1,13 @@
+// https://github.com/DavidAnson/markdownlint#optionsconfig
+// Disabling some rules here as we find them too restrictive.
 {
-  "default": true,
-  "line-length": false,
-  "no-inline-html": {
+  "default": true,            // Include all rules by defauls
+  "line-length": false,       // To allow working with soft wraps in editors
+  "no-inline-html": {         // Sometimes we need to use <img> html tags in GitHub markdown,
+                              // as it doesn't allow setting the image size with markdown tags
     "allowed_elements": ["details", "img"]
   },
-  "ol-prefix": false,
-  "list-indent": false,
-  "ul-indent": false,
-  "no-multiple-blanks": false,
-  "ul-style": false
+  "ul-indent": false,          // To allow indenting the whole list to distinguish it visually
+  "no-multiple-blanks": false  // To allow multiple blank lines between a header and
+                               // the previous paragraph
 }


### PR DESCRIPTION
The previous PR updated a template `new_repository/markdownlint.json` for setting up new repositories, and this one updates this repo's own `.markdownlint.json` :)