### PR TITLE
Add config example (move from cpg-utils)

### DIFF
--- a/.markdownlint.json
+++ b/.markdownlint.json
@@ -8,6 +8,7 @@
     "allowed_elements": ["details", "img"]
   },
   "ul-indent": false,          // To allow indenting the whole list to distinguish it visually
-  "no-multiple-blanks": false  // To allow multiple blank lines between a header and
+  "no-multiple-blanks": false, // To allow multiple blank lines between a header and
                                // the previous paragraph
+  "no-inline-html": false      // allow anchors
 }

--- a/cpg_config_example.toml
+++ b/cpg_config_example.toml
@@ -1,0 +1,60 @@
+# Example of a config containing values typically used by functions in 
+# the `cpg-utils`. These values would be normally set by the analysis-runner
+# automatically.
+
+[workflow]
+# Access level (test, standard, full). Translates into the storage and inputs
+# namespace (test or main).
+access_level = 'standard'
+
+# Dataset name to write intermediate files and use as hail billing project,
+# (unless specified in hail.hail_billing_project).
+dataset = 'seqr'
+
+# Prefix to find docker images referenced in `image_config_yaml_path`.
+image_registry_prefix = 'australia-southeast1-docker.pkg.dev/cpg-common/images'
+
+# Prefix to find reference files referenced in `refdata_yaml_path`
+reference_prefix = 'gs://cpg-reference'
+
+# Template to build HTTP URLs matching the dataset_path of category
+# "web". Should be parametrised by namespace and dataset in Jinja format:
+web_url_template = 'https://{namespace}-web.populationgenomics.org.au/{dataset}'
+
+# GCP project to activate with gcloud, as well as for requester-pays buckets. 
+dataset_gcp_project = 'seqr-308602'
+
+# Hail Batch and Query parameters:
+[hail]
+billing_project = 'seqr'  # passed to ServiceBackend(...)
+pool_label = 'seqr'  # passed to Batch(...)
+# cancel_after_n_failures =  # passed to Batch(...)
+# default_timeout =  # passed to Batch(...)
+# default_memory =  # passed to Batch(...)
+delete_scratch_on_exit = false  # passed to Batch.run(...)
+dry_run = false  # passed to Batch.run(...)
+
+# Docker image URLs, relatives to `[workflow].image_registry_prefix`,
+# can be used as `cpg_utils.hail_batch.image_path('gatk')`
+[images]
+gatk = 'gatk:4.2.6.1'
+# ...
+
+[references]
+genome_build = 'GRCh38'
+
+# Reference files paths, relative to `[workflow].reference_prefix`
+# can be used as `cpg_utils.hail_batch.reference_path('liftover_38_to_37')`
+liftover_38_to_37 = 'liftover/grch38_to_grch37.over.chain.gz'
+# ...
+
+[references.broad]
+# Path to a copy of the Broad reference bucket
+# gs://gcp-public-data--broad-references/hg38/v0
+prefix = 'hg38/v0'
+# This `prefix` here means that `cpg_utils.hail_batch.reference_path('broad/ref_fasta')`
+# assuming `reference_prefix='gs://cpg-reference'`, would return:
+# 'gs://cpg-reference/hg38/v0/dragen_reference/Homo_sapiens_assembly38_masked.fasta'
+
+ref_fasta = 'dragen_reference/Homo_sapiens_assembly38_masked.fasta'
+# ...

--- a/cpg_utils_config.md
+++ b/cpg_utils_config.md
@@ -34,10 +34,29 @@ will be digested into the dictionary:
 }
 ```
 
+## Config in Analysis-Runner jobs
 
-## Config Template
+Analysis-runner incorporates a simple interface for config setting. When setting off a job, the flag `--config` can be used, pointing to a config file (local, or within GCP and accessible with current logged-in credentials).
 
-The `cpg-utils` repository contains a template config, [toml template](https://github.com/populationgenomics/cpg-utils/blob/main/cpg_utils/config-template.toml). This is always loaded first and becomes the base config content. For each additional config file in order, the base config is updated with further content. New content is added, and content with the exact same key is updated/replaced, e.g.
+The `--config` flag can be used multiple times, which will cause the argument files to be <a href="#config-aggregation>aggregated</a> in the order they are defined. When `--config` is set in this way, the job-runner performs the following actions:
+
+1. Locally (where `analysis-runner` is invoked), a [merged configuration file is generated](https://github.com/populationgenomics/analysis-runner/blob/main/analysis_runner/cli_analysisrunner.py#L199-L201), creating a single dictionary
+2. This dictionary is sent with the job definition to the execution server
+3. The merged data is saved in TOML format to a GCP path
+4. The env. variable `CPG_CONFIG_PATH` is set to this new TOML location
+5. Within the driver image `get_config()` can be called safely with no further config setting
+
+If batch jobs are run in containers, passing the environment variable to those containers will allow the same configuration file to be used throughout the Hail Batch. The `cpg-utils.hail_batch.copy_common_env` [method](https://github.com/populationgenomics/cpg-utils/blob/main/cpg_utils/hail_batch.py#L54) facilitates this environment duplication, and [container authentication](https://github.com/populationgenomics/cpg-utils/blob/main/cpg_utils/hail_batch.py#L427-L454) is required to make the file path in GCP accessible.
+
+Even without additional configurations, analysis-runner will insert infrastructure and run-specific attributes, e.g.
+
+- `get_config()['workflow']['access_level']` e.g. test, or standard
+- `get_config()['workflow']['dataset']` e.g. tob-wgs, or acute-care
+
+
+## Config aggregation
+
+When passing the Analysis-runner multiple configs, the configs defined earlier are used as a base that is updated with values from configs defined later. New content is added, and content with the exact same key is updated/replaced, e.g.
 
 Base file:
 
@@ -59,39 +78,16 @@ triangle = 3
 
 Result:
 
-```python
-{
-    'file': 'second.toml',
-    'content': {
-        'square': 4,
-        'triangle': 3
-    }
-}
+```toml
+[file]
+name = "second.toml"
+[content]
+square = 4
+triangle = 3
 ```
 
-It's important to note that the config files are loaded 'left-to-right', so when multiple configuration files are loaded, only the right-most value for any overlapping keys will be retained.  
+It's important to note that the config files are loaded 'left-to-right', so when multiple configuration files are loaded, only the right-most value for any overlapping keys will be retained.
 
-This configuration template contains a number of 'live' attributes, as well as many which are commented out (which is permitted in TOML). These commented out attributes provide examples of useful content in the configuration file, and logical places to place them in the overall config structure (e.g. many examples of content expected to appear in `['workflow']`). If you find a useful config parameter missing from the base template, please create a PR adding new content into the template.
-
-
-
-## Config in Analysis-Runner jobs
-
-Analysis-runner incorporates a simple interface for config setting. When setting off a job, the flag `--config` can be used, pointing to a config file (local, or within GCP and accessible with current logged-in credentials).
-The `--config` flag can be used multiple times, which will cause the argument files to be aggregated in the order they are defined. When `--config` is set in this way, the job-runner performs the following actions:
-
-1. Locally (where `analysis-runner` is invoked), a [merged configuration file is generated](https://github.com/populationgenomics/analysis-runner/blob/main/analysis_runner/cli_analysisrunner.py#L199-L201), creating a single dictionary
-2. This dictionary is sent with the job definition to the execution server
-3. The merged data is saved in TOML format to a GCP path
-4. The env. variable `CPG_CONFIG_PATH` is set to this new TOML location
-5. Within the driver image `get_config()` can be called safely with no further config setting
-
-If batch jobs are run in containers, passing the environment variable to those containers will allow the same configuration file to be used throughout the Hail Batch. The `cpg-utils.hail_batch.copy_common_env` [method](https://github.com/populationgenomics/cpg-utils/blob/main/cpg_utils/hail_batch.py#L54) facilitates this environment duplication, and [container authentication](https://github.com/populationgenomics/cpg-utils/blob/main/cpg_utils/hail_batch.py#L427-L454) is required to make the file path in GCP accessible.
-
-Even without additional configurations, analysis-runner will load the template, and supplement with run-specific attributes, e.g.
-
-- `get_config()['workflow']['access_level']` e.g. test, or standard
-- `get_config()['workflow']['dataset']` e.g. tob-wgs, or acute-care
 
 ## Reading config
 
@@ -113,10 +109,10 @@ Because configuration is loaded lazily, start-up overhead is minimal, but can re
 
 ## Config outside Analysis-Runner
 
-The config utility can be used outside `analysis-runner`, requiring the user to manually set the config file(s) to be read. Configuration files can be set in two ways:
+The config utility can be used outside `analysis-runner` and CPG infrastructure, requiring the user to manually set the config file(s) to be read. Configuration files can be set in two ways:
 
 1. Set the `CPG_CONFIG_PATH` environment variable
-2. Use `set_config_paths` to point to one or more config TOMLs
+2. Use `set_config_paths` to point to one or more config TOMLs:
     - `from cpg_utils.config import set_config_paths`  
 
-When configuration is loaded outside `analysis-runner`, the content is still loaded on top of the base template in the `cpg-utils` package.
+You can refer to [the example configuration TOML](cpg_config_example.toml) in this repository and use it as a template.


### PR DESCRIPTION
[This PR](https://github.com/populationgenomics/cpg-utils/pull/119) removes the `config-template.toml` from cpg-utils as a base for all configs. The motivation for that is that the template contained values relevant purely for workflows (so it is moved to `cpg-workflows`). However, another value for the template was that it served as a documentation for running things outside of AR, and it was referenced for this purpose in this repo's `cpg_utils_config.md`. 

For service this purpose, I'm moving the template here, and updating the configs docs to reflect that.

Slack discussion: https://centrepopgen.slack.com/archives/C018KFBCR1C/p1666918967093519