### PR TITLE
Zscaler docs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 .DS_Store
 .idea
 .vscode
+.python-version

--- a/README.md
+++ b/README.md
@@ -11,6 +11,7 @@ the `#team-data` or `#software-questions` channels).
 - Setup:
     - [Getting started](getting_started.md)
     - [Setting up your terminal](terminal.md)
+    - [Setting up certificates from ZScaler](certificates.md)
     - [Git + Github](git.md)
     - [Python](python.md)
     - [Setting up code editors](code_editors.md)

--- a/certificates.md
+++ b/certificates.md
@@ -28,5 +28,10 @@ export REQUESTS_CA_BUNDLE="$HOME/.mac-ca-roots"
 export NODE_EXTRA_CA_CERTS=${CERT_PATH}
 ```
 
+<<<<<<< Updated upstream
 You can configure the environment variables for additional software using the instructions from: https://help.zscaler.com/zia/adding-custom-certificate-application-specific-trust-store
+=======
+You can configure the environment variables for additional software using the instructions from: [Adding Custom Certificate to an Application Specific Trust Store
+](https://help.zscaler.com/zia/adding-custom-certificate-application-specific-trust-store)
+>>>>>>> Stashed changes
 

--- a/certificates.md
+++ b/certificates.md
@@ -28,10 +28,6 @@ export REQUESTS_CA_BUNDLE="$HOME/.mac-ca-roots"
 export NODE_EXTRA_CA_CERTS=${CERT_PATH}
 ```
 
-<<<<<<< Updated upstream
-You can configure the environment variables for additional software using the instructions from: https://help.zscaler.com/zia/adding-custom-certificate-application-specific-trust-store
-=======
 You can configure the environment variables for additional software using the instructions from: [Adding Custom Certificate to an Application Specific Trust Store
 ](https://help.zscaler.com/zia/adding-custom-certificate-application-specific-trust-store)
->>>>>>> Stashed changes
 

--- a/certificates.md
+++ b/certificates.md
@@ -1,0 +1,32 @@
+# Setting up certificates from ZScaler
+
+
+As part of the security practices at CPG, we use ZScaler for secure connections from the company devices.
+
+This means a lot of tools will scream about local cert issuer errors, but this can be resolved by providing your ZScaler cert to them.
+
+Firstly, export your ZScaler cert from Keychain Access (assuming you are on macOS):
+
+**Keychain Access -> Certificates ZScaler Root CA -> Right-Click -> Export -> Choose .pem as the file format**.
+
+Save this to a directory on your home folder or dev folder. We will refer to this folder as `PATH_TO_YOUR_CERT_FOLDER` below, so remember it!
+
+Next we export the bundle via the command line with this snippet:
+
+```bash
+(security find-certificate -a -p ls /System/Library/Keychains/SystemRootCertificates.keychain && security find-certificate -a -p ls /Library/Keychains/System.keychain) > $HOME/.mac-ca-roots
+```
+
+Next, we can set environment variables that will point to these certs and this should suppress any errors for Python/NPM packages:
+
+```bash
+export CERT_PATH=PATH_TO_YOUR_CERT_FOLDER/ca.pem
+export CERT_DIR=PATH_TO_YOUR_CERT_FOLDER/
+export SSL_CERT_FILE=${CERT_PATH}
+export SSL_CERT_DIR=${CERT_DIR}
+export REQUESTS_CA_BUNDLE="$HOME/.mac-ca-roots"
+export NODE_EXTRA_CA_CERTS=${CERT_PATH}
+```
+
+You can configure the environment variables for additional software using the instructions from: https://help.zscaler.com/zia/adding-custom-certificate-application-specific-trust-store
+

--- a/python.md
+++ b/python.md
@@ -10,10 +10,21 @@ We strongly recommend using `pyenv` to manage versions of Python. This makes it 
 
 ```shell
 brew install pyenv
+```
 
+You will need to run the following to set up `pyenv` on `zsh`. Make sure to source the `.zshrc` file before running `pyenv` in the next step:
+
+```shell
+echo 'export PYENV_ROOT="$HOME/.pyenv"' >> ~/.zshrc
+echo '[[ -d $PYENV_ROOT/bin ]] && export PATH="$PYENV_ROOT/bin:$PATH"' >> ~/.zshrc
+echo 'eval "$(pyenv init -)"' >> ~/.zshrc
+```
+
+```shell
 pyenv install 3.10.12
 pyenv global 3.10.12
 ```
+
 
 ### Named virtual environments
 


### PR DESCRIPTION
# Description
Custom certificates are annoying to work around when almost every package/tool is raising errors but there's a workaround for the common tools that we would need to do this for.

## Changes Made
Added docs under a new 'Certificates' section on how to set up these certificates for Python, NPM and by extension, apps that use these frameworks.

## Notes

There probably might be more tools that we need to document but this is all I have come across so far. 