### PR TITLE
Instructions to restart Hail after offline database migrations / Reflect that we're now mostly on Python 3.11

### DIFF
--- a/hail.md
+++ b/hail.md
@@ -504,7 +504,6 @@ This is another process done on the `hail-dev` VM:
 
 ```bash
 cd ~/hail
-make clean-image-targets
 make -C batch deploy NAMESPACE=default
 ```
 

--- a/hail.md
+++ b/hail.md
@@ -500,6 +500,15 @@ curl -X POST -H "Authorization: Bearer $(jq -r .default ~/.hail/tokens.json)" \
 This will print a link to the [CI dashboard](https://ci.hail.populationgenomics.org.au/batches) batch.
 
 **Warning**: Some changes that involve a database migration will result in the batch service being shut down. You'll then need to [bring it back up manually](https://github.com/hail-is/hail/blob/main/dev-docs/development-process.md#merge--deploy).
+This is another process done on the `hail-dev` VM:
+
+```bash
+cd ~/hail
+make clean-image-targets
+make -C batch deploy NAMESPACE=default
+```
+
+As usual, don't forget to stop the [`hail-dev` VM](https://console.cloud.google.com/compute/instancesDetail/zones/australia-southeast1-b/instances/hail-dev?project=hail-295901) afterwards.
 
 ### Hail Batch SQL database
 

--- a/python.md
+++ b/python.md
@@ -2,7 +2,7 @@
 
 The CPG is mostly a Python shop! We strongly recommend using virtual environments (over conda) to manage Python.
 
-We try to stay relatively up-to-date, most of our tools use Python 3.10 (with a few rare 3.8 exceptions), some are using 3.11 and 3.12. This can be super confusing!
+We try to stay relatively up-to-date, most of our tools use Python 3.11 (with a few rare 3.8 exceptions), some are using 3.10 or 3.12. This can be super confusing!
 
 ## Managing Python versions
 
@@ -21,8 +21,8 @@ echo 'eval "$(pyenv init -)"' >> ~/.zshrc
 ```
 
 ```shell
-pyenv install 3.10.12
-pyenv global 3.10.12
+pyenv install 3.11.12
+pyenv global 3.11.12
 ```
 
 ### Named virtual environments


### PR DESCRIPTION
A couple of unrelated documentation updates:

* Update our basic instructions to reflect that Python 3.11 is now the best starting point — this was a source of confusion for someone I was donut-wise pair-programming with recently;

* The link in the preceding sentence points to upstream's instructions for restarting Hail; this PR adds specific instructions for CPG's context.