### PR TITLE
docs(hail): troubleshoot dev deploy "Unauthorized" failures

### DIFF
--- a/hail.md
+++ b/hail.md
@@ -370,7 +370,7 @@ mysql --defaults-file=/sql-config/sql-config.cnf
 
 If deploy steps that run `kubectl` fail with:
 
-```
+```text
 error: You must be logged in to the server (Unauthorized)
 ```
 

--- a/hail.md
+++ b/hail.md
@@ -366,6 +366,95 @@ apt update && apt install -y mysql-client
 mysql --defaults-file=/sql-config/sql-config.cnf
 ```
 
+### Troubleshooting: dev deploy fails with `Unauthorized`
+
+If a dev deploy fails with an error like:
+
+```
+error: You must be logged in to the server (Unauthorized)
+```
+
+this is usually **not** a problem with the step that reports it — it means the
+Kubernetes token the deploy jobs use to talk to the cluster has stopped working, so
+every `kubectl` call in the deploy fails.
+
+You'll typically see it first in the `create_test_database_server_config` job (the
+earliest step that runs `kubectl`), on its very first command:
+
+```
+Running: SECRET_JSON=$(kubectl get secret database-server-config -n $NAMESPACE -o json)
+error: You must be logged in to the server (Unauthorized)
+```
+
+and it recurs in later `kubectl` steps such as `create_ssl_config_hail_root`:
+
+```
+error: failed to create secret Unauthorized
+error: You must be logged in to the server (Unauthorized)
+```
+
+#### Root cause
+
+Deploy steps that run `kubectl` (those with a `serviceAccount:` in `build.yaml`)
+authenticate as the `admin` service account in your namespace. The CI driver reads
+the token from the `admin-token` secret in your namespace, builds a kubeconfig from
+it, and mounts it into the job.
+
+That `admin-token` is a **legacy service-account token**. GKE progressively
+invalidates legacy service-account tokens that haven't been used for a while (the
+`LegacyServiceAccountTokenCleanUp` behaviour), so after a gap between deploys the
+stored token stops authenticating and every `kubectl` call returns `401 Unauthorized`.
+Re-running the deploy doesn't help: the `default_ns` step applies the secret with
+`kubectl apply`, which won't regenerate the token of an already-existing secret.
+
+#### Diagnose locally
+
+Point `kubectl` at the `vdc` cluster and test the stored token directly. These are
+all read-only checks:
+
+```bash
+export NAMESPACE=<your-hail-username>
+gcloud container clusters get-credentials vdc --location=australia-southeast1-b
+
+# The service account, RBAC and secret usually all still exist and look fine:
+kubectl -n $NAMESPACE get sa admin
+kubectl -n $NAMESPACE get secret admin-token
+kubectl -n $NAMESPACE get role,rolebinding
+
+# The tell-tale check — try to authenticate as admin using the *stored* token:
+TOKEN=$(kubectl -n $NAMESPACE get secret admin-token -o jsonpath='{.data.token}' | base64 -d)
+kubectl auth whoami --token="$TOKEN"
+```
+
+If that last command prints `error: You must be logged in to the server (Unauthorized)`
+instead of `system:serviceaccount:$NAMESPACE:admin`, the stored token is the problem.
+
+#### Fix
+
+Delete and recreate the `admin-token` secret so the token controller mints a fresh,
+valid token:
+
+```bash
+kubectl -n $NAMESPACE delete secret admin-token
+kubectl -n $NAMESPACE apply -f - <<EOF
+apiVersion: v1
+kind: Secret
+type: kubernetes.io/service-account-token
+metadata:
+  name: admin-token
+  namespace: $NAMESPACE
+  annotations:
+    kubernetes.io/service-account.name: admin
+EOF
+
+# Verify it now authenticates (should print system:serviceaccount:$NAMESPACE:admin):
+sleep 3
+TOKEN=$(kubectl -n $NAMESPACE get secret admin-token -o jsonpath='{.data.token}' | base64 -d)
+kubectl auth whoami --token="$TOKEN"
+```
+
+Once `kubectl auth whoami` reports the `admin` service account, re-run your dev deploy.
+
 ### Syncing local changes to pod
 
 Instead of manually dev-deploying for every change, you can synchronise your local changes with the k8s pod, using the `devbin/sync.py` script in the Hail repository.

--- a/hail.md
+++ b/hail.md
@@ -368,71 +368,31 @@ mysql --defaults-file=/sql-config/sql-config.cnf
 
 ### Troubleshooting: dev deploy fails with `Unauthorized`
 
-If a dev deploy fails with an error like:
+If deploy steps that run `kubectl` fail with:
 
 ```
 error: You must be logged in to the server (Unauthorized)
 ```
 
-this is usually **not** a problem with the step that reports it — it means the
-Kubernetes token the deploy jobs use to talk to the cluster has stopped working, so
-every `kubectl` call in the deploy fails.
+the problem usually isn't the reporting step. Those steps authenticate as the `admin`
+service account using the token in your namespace's `admin-token` secret, which is a
+**legacy service-account token**. GKE invalidates legacy tokens that haven't been used
+for a while (`LegacyServiceAccountTokenCleanUp`), so after a gap between deploys the
+stored token stops working and every `kubectl` call fails. Re-running won't fix it —
+`kubectl apply` doesn't regenerate the token of an existing secret.
 
-You'll typically see it first in the `create_test_database_server_config` job (the
-earliest step that runs `kubectl`), on its very first command:
-
-```
-Running: SECRET_JSON=$(kubectl get secret database-server-config -n $NAMESPACE -o json)
-error: You must be logged in to the server (Unauthorized)
-```
-
-and it recurs in later `kubectl` steps such as `create_ssl_config_hail_root`:
-
-```
-error: failed to create secret Unauthorized
-error: You must be logged in to the server (Unauthorized)
-```
-
-#### Root cause
-
-Deploy steps that run `kubectl` (those with a `serviceAccount:` in `build.yaml`)
-authenticate as the `admin` service account in your namespace. The CI driver reads
-the token from the `admin-token` secret in your namespace, builds a kubeconfig from
-it, and mounts it into the job.
-
-That `admin-token` is a **legacy service-account token**. GKE progressively
-invalidates legacy service-account tokens that haven't been used for a while (the
-`LegacyServiceAccountTokenCleanUp` behaviour), so after a gap between deploys the
-stored token stops authenticating and every `kubectl` call returns `401 Unauthorized`.
-Re-running the deploy doesn't help: the `default_ns` step applies the secret with
-`kubectl apply`, which won't regenerate the token of an already-existing secret.
-
-#### Diagnose locally
-
-Point `kubectl` at the `vdc` cluster and test the stored token directly. These are
-all read-only checks:
+Confirm the stored token is dead:
 
 ```bash
 export NAMESPACE=<your-hail-username>
 gcloud container clusters get-credentials vdc --location=australia-southeast1-b
 
-# The service account, RBAC and secret usually all still exist and look fine:
-kubectl -n $NAMESPACE get sa admin
-kubectl -n $NAMESPACE get secret admin-token
-kubectl -n $NAMESPACE get role,rolebinding
-
-# The tell-tale check — try to authenticate as admin using the *stored* token:
 TOKEN=$(kubectl -n $NAMESPACE get secret admin-token -o jsonpath='{.data.token}' | base64 -d)
 kubectl auth whoami --token="$TOKEN"
 ```
 
-If that last command prints `error: You must be logged in to the server (Unauthorized)`
-instead of `system:serviceaccount:$NAMESPACE:admin`, the stored token is the problem.
-
-#### Fix
-
-Delete and recreate the `admin-token` secret so the token controller mints a fresh,
-valid token:
+If this prints `Unauthorized` instead of `system:serviceaccount:$NAMESPACE:admin`,
+delete and recreate the secret so a fresh token is minted:
 
 ```bash
 kubectl -n $NAMESPACE delete secret admin-token
@@ -447,13 +407,11 @@ metadata:
     kubernetes.io/service-account.name: admin
 EOF
 
-# Verify it now authenticates (should print system:serviceaccount:$NAMESPACE:admin):
+# Verify (should now print system:serviceaccount:$NAMESPACE:admin), then re-run the deploy:
 sleep 3
 TOKEN=$(kubectl -n $NAMESPACE get secret admin-token -o jsonpath='{.data.token}' | base64 -d)
 kubectl auth whoami --token="$TOKEN"
 ```
-
-Once `kubectl auth whoami` reports the `admin` service account, re-run your dev deploy.
 
 ### Syncing local changes to pod
 


### PR DESCRIPTION
## What

Adds a **Troubleshooting: dev deploy fails with `Unauthorized`** subsection to the Developer deploy section of `hail.md`.

## Why

Dev deploys can fail with:

```
error: You must be logged in to the server (Unauthorized)
```

This surfaces first in the `create_test_database_server_config` job (the earliest step to run `kubectl`) and recurs in later `kubectl` steps such as `create_ssl_config_hail_root` (`error: failed to create secret Unauthorized`). The failing step is a red herring — the real cause is that GKE has invalidated the legacy `admin-token` service-account token in the developer's namespace, so every `kubectl` call in the deploy gets a 401. Re-running doesn't help because `default_ns`'s `kubectl apply` won't regenerate an existing secret's token.

## Contents of the new section

- The exact errors and which jobs they appear in
- Root cause (legacy SA-token invalidation via `LegacyServiceAccountTokenCleanUp`)
- Read-only local diagnosis steps (`kubectl auth whoami --token=...` against the stored token)
- The fix: delete + recreate the `admin-token` secret so the token controller mints a fresh token

Verified end-to-end against a live namespace: the diagnosis reproduces the 401, and the fix restores `system:serviceaccount:<ns>:admin` auth.
